### PR TITLE
Fix player level tooltip and add unitframe target name position

### DIFF
--- a/Config/_Gui.lua
+++ b/Config/_Gui.lua
@@ -538,6 +538,20 @@ function Gui:OnEnable()
                     }
                 },
                 {
+                    mobnamepos = {
+                        key = 'unitframes.mobnamepos',
+                        type = 'dropdown',
+                        label = 'Target Name Position',
+                        options = {
+                            { value = 'above', text = 'Above Healthbar' },
+                            { value = 'below', text = 'Below Healthbar' },
+                            { value = 'inbar', text = 'In Healthbar' }
+                        },
+                        column = 4,
+                        order = 2
+                    }
+                },
+                {
                     textsize = {
                         key = 'unitframes.textsize',
                         type = 'slider',

--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -43,6 +43,7 @@ local defaults = {
             hitindicator = false,
             links = false,
             elite = false,
+            mobnamepos = 'above',
             size = 1,
             textsize = 11,
             player = {

--- a/Modules/Tooltip/_Core.lua
+++ b/Modules/Tooltip/_Core.lua
@@ -131,16 +131,97 @@ function Module:OnEnable()
                 cfg.barColor = color
                 GameTooltipStatusBar:SetStatusBarColor(color.r, color.g, color.b)
                 _G["GameTooltipTextLeft1"]:SetTextColor(color.r, color.g, color.b)
-                --color textleft2 by guildcolor
+                --guild + level lines
                 local guildName, guildRank = GetGuildInfo(unit)
-                if guildName then
-                    _G["GameTooltipTextLeft2"]:SetText("<" .. guildName .. "> [" .. guildRank .. "]")
-                    _G["GameTooltipTextLeft2"]:SetTextColor(unpack(cfg.guildColor))
+                local playerLevel = UnitLevel(unit)
+
+                local function GetLine(i)
+                    return _G["GameTooltipTextLeft" .. i]
                 end
-                local levelLine = guildName and _G["GameTooltipTextLeft3"] or _G["GameTooltipTextLeft2"]
-                local l = UnitLevel(unit)
-                local color = GetCreatureDifficultyColor((l > 0) and l or 999)
-                levelLine:SetTextColor(color.r, color.g, color.b)
+
+                local function GetLineText(i)
+                    local line = GetLine(i)
+                    return line and line:GetText() or nil
+                end
+
+                local function FindLineByTextPredicate(minLine, maxLine, predicate)
+                    for i = minLine, maxLine do
+                        local text = GetLineText(i)
+                        if text and text ~= "" and predicate(text, i) then
+                            return i
+                        end
+                    end
+                    return nil
+                end
+
+                local function FindEmptyLine(minLine, maxLine)
+                    for i = minLine, maxLine do
+                        local text = GetLineText(i)
+                        if not text or text == "" then
+                            return i
+                        end
+                    end
+                    return nil
+                end
+
+                local maxLine = math.min(self:NumLines() or GameTooltip:NumLines(), 15)
+
+                if guildName then
+                    local guildFormatted = "<" .. guildName .. ">" .. (guildRank and (" [" .. guildRank .. "]") or "")
+
+                    local guildIndex = FindLineByTextPredicate(2, maxLine, function(text)
+                        return text:find(guildName, 1, true) ~= nil
+                    end)
+
+                    if not guildIndex then
+                        guildIndex = 2
+                        local preserved = GetLineText(2)
+
+                        local line2 = GetLine(2)
+                        if line2 then
+                            line2:SetText(guildFormatted)
+                            line2:SetTextColor(unpack(cfg.guildColor))
+                        end
+
+                        if preserved and preserved ~= "" and preserved:find(guildName, 1, true) == nil then
+                            local emptyIndex = FindEmptyLine(3, maxLine)
+                            if emptyIndex then
+                                local emptyLine = GetLine(emptyIndex)
+                                if emptyLine then
+                                    emptyLine:SetText(preserved)
+                                    self:Show()
+                                end
+                            else
+                                self:AddLine(preserved)
+                                self:Show()
+                                maxLine = math.min(self:NumLines() or GameTooltip:NumLines(), 15)
+                            end
+                        end
+                    else
+                        local guildLine = GetLine(guildIndex)
+                        if guildLine then
+                            guildLine:SetText(guildFormatted)
+                            guildLine:SetTextColor(unpack(cfg.guildColor))
+                        end
+                    end
+                end
+
+                local levelIndex
+                if playerLevel and playerLevel > 0 then
+                    local levelStr = tostring(playerLevel)
+                    levelIndex = FindLineByTextPredicate(2, maxLine, function(text)
+                        if guildName and text:find(guildName, 1, true) then return false end
+                        return text:find(levelStr, 1, true) ~= nil
+                    end)
+                end
+
+                if levelIndex then
+                    local levelLine = GetLine(levelIndex)
+                    if levelLine then
+                        local lvlColor = GetCreatureDifficultyColor((playerLevel > 0) and playerLevel or 999)
+                        levelLine:SetTextColor(lvlColor.r, lvlColor.g, lvlColor.b)
+                    end
+                end
                 --afk?
                 if UnitIsAFK(unit) then
                     self:AppendText((" |cff%s<AFK>|r"):format(cfg.afkColorHex))

--- a/Modules/UnitFrames/_Target.lua
+++ b/Modules/UnitFrames/_Target.lua
@@ -6,6 +6,7 @@ function Module:OnEnable()
         texture = SUI.db.profile.general.texture,
         size = SUI.db.profile.unitframes.size,
         pvpbadge = SUI.db.profile.general.pvpbadge,
+        mobnamepos = SUI.db.profile.unitframes.mobnamepos,
         module = SUI.db.profile.modules.unitframes
     }
 
@@ -15,13 +16,24 @@ function Module:OnEnable()
         --FocusFrame:SetScale(db.size)
 
         local function SUITargetFrame(self, forceNormalTexture)
+            local function ApplyMobNamePosition()
+                if not self.name or not self.healthbar then return end
+                self.name:ClearAllPoints()
+                if db.mobnamepos == 'below' then
+                    self.name:SetPoint("TOPLEFT", self.healthbar, "BOTTOMLEFT", 10, -2)
+                elseif db.mobnamepos == 'inbar' then
+                    self.name:SetPoint("CENTER", self.healthbar, "CENTER", 0, 0)
+                else
+                    self.name:SetPoint("BOTTOMLEFT", self.healthbar, "TOPLEFT", 10, 2)
+                end
+            end
+
             if (db.style == 'Big') then
                 local classification = UnitClassification(self.unit);
                 self.highLevelTexture:SetPoint("CENTER", self.levelText, "CENTER", 0, 0);
                 self.deadText:SetPoint("CENTER", self.healthbar, "CENTER", 0, 0);
                 self.nameBackground:Hide();
                 --self.threatIndicator:SetTexture([[Interface\TargetingFrame\UI-TargetingFrame-Flash]]);
-                self.name:SetPoint("LEFT", self, 15, 36);
                 self.healthbar:SetSize(119, 26);
                 self.healthbar:SetPoint("TOPLEFT", 5, -24);
                 if (self.healthbar.LeftText) then
@@ -73,7 +85,6 @@ function Module:OnEnable()
                     if (classification == "minus") then
                         self.Background:SetSize(119, 12);
                         self.Background:SetPoint("BOTTOMLEFT", self, "BOTTOMLEFT", 7, 47);
-                        self.name:SetPoint("LEFT", self, 16, 19);
                         self.healthbar:ClearAllPoints();
                         self.healthbar:SetPoint("LEFT", 5, 3);
                         self.healthbar:SetHeight(12);
@@ -107,6 +118,7 @@ function Module:OnEnable()
                     end
                 end
                 self.healthbar.lockColor = true;
+                ApplyMobNamePosition()
             end
 
             if (db.texture ~= 'Default') then


### PR DESCRIPTION
- Fixed player level not shown if player has a guild.

Before:
<img width="266" height="99" alt="image" src="https://github.com/user-attachments/assets/3eaa6825-b76a-4c39-8139-7b7dc3c75bd1" />

After:
<img width="241" height="78" alt="Bildschirmfoto_20260106_000727" src="https://github.com/user-attachments/assets/a3d7992a-3736-4f30-8027-cfa8a7eb1d0c" />

- Added Unitframe target name position
<img width="236" height="93" alt="Bildschirmfoto_20260106_000914" src="https://github.com/user-attachments/assets/35673208-46e4-4cf2-9ce0-a1d5dd673f92" />
<img width="845" height="550" alt="Bildschirmfoto_20260106_000828" src="https://github.com/user-attachments/assets/ddc09315-1b66-4fc6-b0dc-d7b50b7d2340" />

