### PR TITLE
fix: skip UnitIsAFK check during combat to prevent taint error

### DIFF
--- a/Modules/Tooltip/_Core.lua
+++ b/Modules/Tooltip/_Core.lua
@@ -145,8 +145,8 @@ function Module:OnEnable()
                 local l = UnitLevel(unit)
                 local color = GetCreatureDifficultyColor((l > 0) and l or 999)
                 levelLine:SetTextColor(color.r, color.g, color.b)
-                --afk?
-                if UnitIsAFK(unit) then
+                --afk? (skip in combat: UnitIsAFK returns secret boolean during combat)
+                if not InCombatLockdown() and UnitIsAFK(unit) then
                     self:AppendText((" |cff%s<AFK>|r"):format(cfg.afkColorHex))
                 end
             end


### PR DESCRIPTION
## Problem

`UnitIsAFK()` returns a secret boolean during combat, which cannot be tested in any conditional (including via `pcall`) when the execution context is tainted by SUI.

This causes the following error when hovering over party/raid frames while in combat with Tooltip Style set to Custom:

```
Tooltip/_Core.lua:149: attempt to perform boolean test on a secret boolean value (tainted by 'SUI')
```

Closes #226.

## Fix

Use `InCombatLockdown()` to skip the AFK check entirely during combat:

```lua
if not InCombatLockdown() and UnitIsAFK(unit) then
    self:AppendText((" |cff%s<AFK>|r"):format(cfg.afkColorHex))
end
```

Since players cannot be AFK during combat, this has no functional impact on the AFK display feature.
